### PR TITLE
Expose getBounds separate to getCenter

### DIFF
--- a/lib/get-bounds.js
+++ b/lib/get-bounds.js
@@ -1,0 +1,26 @@
+
+// - [ ] account for arc edges
+
+var _ = require('lodash')
+
+module.exports = function () {
+
+  var xValues = []
+  var yValues = []
+
+  this.commands.forEach(function (command) {
+    if (typeof command.params.x !== 'undefined') {
+      xValues.push(command.params.x)
+    }
+    if (typeof command.params.y !== 'undefined') {
+      yValues.push(command.params.y)
+    }
+  })
+
+  return {
+    minX: _.min(xValues),
+    maxX: _.max(xValues),
+    minY: _.min(yValues),
+    maxY:_.max(yValues)
+  }
+}

--- a/lib/get-center.js
+++ b/lib/get-center.js
@@ -1,30 +1,13 @@
 
 // - [ ] account for arc edges
 
-var _ = require('lodash')
-
 module.exports = function () {
 
-  var xValues = []
-  var yValues = []
+  var bounds = this.getBounds()
 
-  this.commands.forEach(function (command) {
-    if (typeof command.params.x !== 'undefined') {
-      xValues.push(command.params.x)
-    }
-    if (typeof command.params.y !== 'undefined') {
-      yValues.push(command.params.y)
-    }
-  })
-
-  var minX = _.min(xValues)
-  var maxX = _.max(xValues)
-  var minY = _.min(yValues)
-  var maxY = _.max(yValues)
   return {
-    x: (maxX - minX) / 2 + minX,
-    y: (maxY - minY) / 2 + minY
+    x: (bounds.maxX - bounds.minX) / 2 + bounds.minX,
+    y: (bounds.maxY - bounds.minY) / 2 + bounds.minY
   }
 
 }
-

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -8,6 +8,7 @@ var reflectX = require('./reflect-x')
 var reflectY = require('./reflect-y')
 var toAbsolute = require('./to-absolute')
 var getCenter = require('./get-center')
+var getBounds = require('./get-bounds')
 
 module.exports = function (string, options) {
 
@@ -20,6 +21,7 @@ module.exports = function (string, options) {
   ast.reflectY = reflectY
   ast.toAbsolute = toAbsolute
   ast.getCenter = getCenter
+  ast.getBounds = getBounds
   ast.commands = []
 
   function parseRawString (str) {
@@ -84,4 +86,3 @@ module.exports = function (string, options) {
   return ast
 
 }
-

--- a/test/index.js
+++ b/test/index.js
@@ -104,6 +104,11 @@ describe('Transform methods', function () {
     assert.deepEqual(center, { x: 16, y: 16 })
   })
 
+  it('should calculate the bounds', function () {
+    var center = ast.getBounds()
+    assert.deepEqual(center, { minX: 0, maxX: 32, minY: 0, maxY: 32 })
+  })
+
   it('should rotate -90°', function () {
     var rotated = ast.rotate(-90)
     assert.deepEqual(
@@ -139,4 +144,3 @@ describe('Expand strokes', function () {
   it('should expand curves')
 
 })
-


### PR DESCRIPTION
### Change
Move functionality currently being used to find the bounds of the path to calculate the center, into a separate method that can be called directly.

### Reason
This change gives the consumer the ability to to find the the outer rectangular boundary of a given path.

### Example
``` javascript
var ast = parse('M0 16 L16 32 L32 16 L16 0z')
var bounds = ast.getBounds() // { minX: 0, maxX: 32, minY: 0, maxY: 32 }
```